### PR TITLE
fix(normalisation): handle constant channels in midtones normalisation

### DIFF
--- a/fitsbolt/normalisation/normalisation.py
+++ b/fitsbolt/normalisation/normalisation.py
@@ -512,6 +512,12 @@ def _midtones_normalisation(data, cfg):
         min_value = _compute_min_value(data[..., c], cfg)
         # include necessary clipping
         data[..., c] = np.clip(data[..., c], min_value, max_value)
+
+        # Skip MTF for constant channels (avoids division by zero)
+        if min_value >= max_value:
+            data[..., c] = 0.0
+            continue
+
         normalised_channel = (data[..., c] - min_value) / (max_value - min_value)
 
         m = _find_mean_of_normalised(normalised_channel, cfg)


### PR DESCRIPTION
## Summary
- When a channel has `max_value == min_value` (e.g. all zeros in a faint astronomical source), the per-channel division at line 515 produces NaN/inf, which fails the assertion `x.max() <= 1` in `_apply_midtones_on_normalised_data`
- Skip the MTF for constant channels and set them to 0.0, consistent with the `min_value < max_value` guard already present at the final rescale step (lines 527-533)

## Context
Encountered when loading small FITS cutouts (5-60px) with 4 HDU extensions where some bands are entirely zero for faint sources.

## Test plan
- [x] Verify midtones normalisation works on images with constant channels
- [x] Verify existing midtones behaviour is unchanged for normal images