### PR TITLE
Speed up general channel combination with float32 BLAS matmul

### DIFF
--- a/fitsbolt/channel_mixing.py
+++ b/fitsbolt/channel_mixing.py
@@ -53,7 +53,7 @@ def batch_channel_combination(
     Will typically return a float array, unless output_dtype is set.
 
     Includes fast paths for common cases (identity, channel slicing,
-    single-channel broadcast) to avoid expensive tensordot operations.
+    single-channel broadcast) that avoid the general matrix multiply.
 
     Args:
         images (np.ndarray): Array of (n_images, H, W, n_extensions)
@@ -83,9 +83,19 @@ def batch_channel_combination(
         combined = np.repeat(images, broadcast_n, axis=-1)
         return _convert_dtype(combined, output_dtype)
 
-    # --- General case: tensordot ---
-    # Contract the last axis of images (n_extensions) with the last axis of channel_combination (n_extensions)
-    # images: (n_images, H, W, n_extensions) @ channel_combination.T: (n_extensions, n_output_channels)
-    # Result: (n_images, H, W, n_output_channels)
-    combined = np.tensordot(images, cc.T, axes=([3], [0]))
+    # --- General case: 2D matmul (BLAS GEMM) ---
+    # Collapse the leading (n_images, H, W) axes into one and contract the
+    # input-channel axis with a single matrix multiply, which dispatches to a
+    # BLAS GEMM kernel. np.tensordot misses that kernel for this shape and is
+    # dramatically slower, and float64 GEMM is in turn far slower than float32,
+    # so compute in the input's float precision: a float32 batch stays float32
+    # (sgemm) instead of being upcast to float64. The output dtype is still
+    # governed by output_dtype via _convert_dtype, so callers requesting a
+    # specific dtype are unaffected; only the default (output_dtype=None) now
+    # returns float32 for a float32 input rather than float64.
+    compute_dtype = np.result_type(images.dtype, np.float32)
+    leading_shape = images.shape[:-1]
+    flat = np.ascontiguousarray(images.reshape(-1, n_in), dtype=compute_dtype)
+    weights = cc.T.astype(compute_dtype, copy=False)
+    combined = (flat @ weights).reshape(*leading_shape, n_out)
     return _convert_dtype(combined, output_dtype)

--- a/tests/test_channel_mixing.py
+++ b/tests/test_channel_mixing.py
@@ -357,6 +357,34 @@ class TestBatchChannelCombination:
         expected_avg = (cutouts[:, :, :, 0] + cutouts[:, :, :, 1]) / 2
         np.testing.assert_allclose(result[:, :, :, 2], expected_avg)
 
+    def test_float32_input_stays_float32(self):
+        """General-path float32 input must combine in float32, not upcast to float64.
+
+        The matmul path computes in the input's float precision for speed; a
+        float32 batch should therefore yield a float32 result (the default
+        output_dtype=None case) rather than the float64 a tensordot would give.
+        """
+        cutouts = np.random.rand(4, 5, 6, 3).astype(np.float32)
+        weights = np.array([[1.0, 0.0, 0.75], [0.0, 1.0, 0.75]])  # general 2x3 matrix
+
+        result = batch_channel_combination(cutouts, weights)
+
+        assert result.dtype == np.float32
+        expected = np.tensordot(cutouts, weights.T, axes=([3], [0]))
+        np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
+    def test_non_contiguous_input(self):
+        """A non-contiguous batch (e.g. a strided view) must combine correctly."""
+        full = np.random.rand(4, 5, 6, 3).astype(np.float32)
+        cutouts = full[:, ::2, :, :]  # strided, non-contiguous along axis 1
+        weights = np.array([[0.5, 0.3, 0.2], [0.1, 0.1, 0.8]])
+
+        result = batch_channel_combination(cutouts, weights)
+
+        expected = np.tensordot(cutouts, weights.T, axes=([3], [0]))
+        assert result.shape == (4, 3, 6, 2)
+        np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
     def test_zero_weight_combinations(self):
         """Test various zero weight combinations."""
         cutouts = np.array([[[[10, 20, 30]]]])  # Shape: (1, 1, 1, 3)


### PR DESCRIPTION
## Summary

- The general-case channel combination upcast the whole batch to **float64** and contracted it with `np.tensordot`, which misses the BLAS GEMM kernel for this shape. Both the upcast and the missed kernel make it slow.
- Replace it with a single 2D **matrix multiply in the input's float precision**: a float32 batch now stays float32 (BLAS `sgemm`) instead of being upcast to float64.
- The fast paths (identity / slice / single-channel broadcast) are unchanged; this only touches the general weighted-combination path.

**Behaviour change:** the output dtype is still governed by `output_dtype` via `_convert_dtype`, so callers requesting a specific dtype are unaffected. Only the default (`output_dtype=None`) now returns **float32 for a float32 input** rather than float64 (no fake-precision upcast). Both internal callers (`read.py`, `image_loader.py`) pass an explicit `output_dtype`, so they are unaffected.

## Benchmark

```python
import numpy as np, time
from fitsbolt.channel_mixing import batch_channel_combination

# visnir3-like batch: 64 cutouts, 180x180, 3 input extensions -> 3 output channels
batch = np.random.default_rng(0).exponential(50.0, (64, 180, 180, 3)).astype(np.float32)
cc = np.array([[1.0, 0.0, 0.75], [0.0, 1.0, 0.75], [0.5, 0.5, 0.0]])  # general (non fast-path) matrix

def timed(fn, reps=20):
    fn()  # warm
    start = time.perf_counter()
    for _ in range(reps):
        out = fn()
    return (time.perf_counter() - start) / reps * 1000, out

ms, out = timed(lambda: batch_channel_combination(batch, cc))
print(f"{ms:.2f} ms/batch  ({64 / ms * 1000:.0f} cutouts/s/core)  dtype={out.dtype}")

ref = np.tensordot(batch.astype(np.float64), cc.T, axes=([3], [0]))
print(f"max |relative diff| vs float64 tensordot: {np.abs((out - ref) / np.maximum(np.abs(ref), 1e-6)).max():.1e}")
```

| | ms/batch | cutouts/s/core | dtype |
|---|---:|---:|---|
| before (float64 tensordot) | 281.56 | 227 | float64 |
| **after (float32 matmul)** | **1.46** | **43,903** | float32 |

**~190x faster**, agreeing with the previous result to float32 precision (`max |rel diff| = 6e-8`).

## Test plan

- [x] `pytest tests/test_channel_mixing.py` — 26 passed (added `test_float32_input_stays_float32`, `test_non_contiguous_input`)
- [x] `pytest tests/` — 164 passed, 2 skipped (full suite)
- [x] `ruff check` — clean
