### PR TITLE
Switch to Opencv2 resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Resizes image arrays to specified dimensions.
 resized = fitsbolt.resize_images(
     images=raw_images,
     size=[224, 224],           # Target size [height, width]
-    interpolation_order=1,     # 0-4: nearest, linear, lanczos, 4=inter area (alwayse used for downsizing)
+    interpolation_order=1,     # 0-4: nearest, linear, cubic, lanczos, 4=inter area (alwayse used for downsizing)
     output_dtype=np.float32,   # Recommended: float32 for processing chain
     show_progress=True
 )

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Resizes image arrays to specified dimensions.
 resized = fitsbolt.resize_images(
     images=raw_images,
     size=[224, 224],           # Target size [height, width]
-    interpolation_order=1,     # 0-5, higher = smoother
+    interpolation_order=1,     # 0-4: nearest, linear, lanczos, 4=inter area (alwayse used for downsizing)
     output_dtype=np.float32,   # Recommended: float32 for processing chain
     show_progress=True
 )

--- a/README.md
+++ b/README.md
@@ -384,7 +384,8 @@ fitsbolt provides several normalisation methods for handling astronomical images
 #### General Parameters
 - **output_dtype**: Data type for output images (default: np.uint8)
 - **size**: Target size for resizing [height, width]
-- **interpolation_order**: Order of interpolation for resizing (0-5, default: 1)
+- **interpolation_order**: Order of interpolation for resizing (0-4, default: 1)
+    - 0: cv2.INTER_NEAREST, 1: cv2.INTER_LINEAR, 2: cv2.INTER_CUBIC, 3: cv2.INTER_LANCZOS4, 4: cv2.INTER_AREA # always used for downscaling
 - **num_workers**: Number of worker threads for parallel loading
 
 #### FITS File Parameters

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - astropy>=6.0
   - scikit-image
   - tqdm
+  - opencv-python
   - pytest
   - pillow
   - dotmap

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - astropy>=6.0
   - scikit-image
   - tqdm
-  - opencv-python
+  - opencv-python-headless
   - pytest
   - pillow
   - dotmap

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - astropy>=6.0
   - scikit-image
   - tqdm
-  - opencv-python-headless
   - pytest
   - pillow
   - dotmap
@@ -18,3 +17,4 @@ dependencies:
     - setuptools
     - wheel
     - build
+    - opencv-python-headless>=4.5

--- a/fitsbolt/cfg/create_config.py
+++ b/fitsbolt/cfg/create_config.py
@@ -52,6 +52,7 @@ def create_config(
         fits_extension (list, optional): Extension(s) to use when loading FITS files. Defaults to None.
         interpolation_order (int, optional): Order of interpolation for resizing with opencv2, 0-4. Defaults to 1 = linear
                                              downscaling always uses cv2.INTER_AREA = 4 regardless of this setting.
+                                             0= nearest, 1= linear , 2=cubic, 3= lanczos4, 4= inter_area
         n_output_channels (int,optional): number of output channels. Defaults to 3.
         normalisation_method (NormalisationMethod, optional): Method for normalising images.
                             Defaults to NormalisationMethod.CONVERSION_ONLY.

--- a/fitsbolt/cfg/create_config.py
+++ b/fitsbolt/cfg/create_config.py
@@ -50,7 +50,8 @@ def create_config(
         output_dtype (type, optional): Data type for output images. Defaults to np.uint8.
         size (list, optional): Target size for image resizing. Defaults to [224, 224]. If None, no resizing.
         fits_extension (list, optional): Extension(s) to use when loading FITS files. Defaults to None.
-        interpolation_order (int, optional): Order of interpolation for resizing with skimage, 0-5. Defaults to 1.
+        interpolation_order (int, optional): Order of interpolation for resizing with opencv2, 0-4. Defaults to 1 = linear
+                                             downscaling always uses cv2.INTER_AREA = 4 regardless of this setting.
         n_output_channels (int,optional): number of output channels. Defaults to 3.
         normalisation_method (NormalisationMethod, optional): Method for normalising images.
                             Defaults to NormalisationMethod.CONVERSION_ONLY.
@@ -110,7 +111,9 @@ def create_config(
     cfg.n_output_channels = n_output_channels  # int, normally 3 for R,G,B
     cfg.num_workers = num_workers
     cfg.force_dtype = force_dtype  # Force output to maintain original dtype after tensor operations
-    # order of interpolation for resizing with skimage, 0-5
+    # order of interpolation for resizing with opencv2,
+    # 0: cv2.INTER_NEAREST, 1: cv2.INTER_LINEAR, 2: cv2.INTER_CUBIC, 3: cv2.INTER_LANCZOS4,
+    # 4: cv2.INTER_AREA # always used for downscaling
     cfg.interpolation_order = interpolation_order
     # Normalisation settings
     cfg.normalisation_method = normalisation_method
@@ -249,7 +252,7 @@ def _return_required_and_optional_keys():
         "normalisation.asinh_scale": ["special_asinh_scale", None, None, False, None],
         "normalisation.asinh_clip": ["special_asinh_clip", None, None, False, None],
         "normalisation.asinh_n_samples": [int, 1, None, True, None],
-        "interpolation_order": [int, 0, 5, False, None],  # 0-5 for skimage interpolation"
+        "interpolation_order": [int, 0, 4, False, None],  # 0-4 for opencv2 interpolation
         "output_dtype": [type, None, None, False, None],
         # Optional numeric parameters
         "normalisation.maximum_value": [float, None, None, True, None],

--- a/fitsbolt/image_loader.py
+++ b/fitsbolt/image_loader.py
@@ -153,7 +153,8 @@ def load_and_process_images(
                                                - A list of integers or strings to combine multiple extensions
                                                - For multi-FITS mode: list of extensions matching filepaths structure
                                                Uses the first extension (0) if None.
-        interpolation_order (int, optional): Order of interpolation for resizing with skimage, 0-5. Defaults to 1.
+        interpolation_order (int, optional): Order of interpolation for resizing with opencv2, 0-4. Defaults to 1 = linear
+                                             downscaling always uses cv2.INTER_AREA = 4 regardless of this setting.
         normalisation_method (NormalisationMethod, optional): Normalisation method to use.
                                                 Defaults to NormalisationMethod.CONVERSION_ONLY.
         channel_combination (dict, optional): Dictionary defining how to combine FITS extensions into output channels.

--- a/fitsbolt/resize.py
+++ b/fitsbolt/resize.py
@@ -172,7 +172,7 @@ def _resize_image(image, cfg, output_dtype=None, do_type_conversion=True):
         # cv2 internally returns the input dtype
         image = resize_func(
             np.ascontiguousarray(image, dtype=np.float32),
-            cfg.size,
+            (cfg.size[1], cfg.size[0]),  # cv2 expects (width, height)
             interpolation=interpolation_flag,
         )
         if readd_channel:

--- a/fitsbolt/resize.py
+++ b/fitsbolt/resize.py
@@ -46,6 +46,7 @@ def resize_images(
 ):
     """
     Resize an image to the specified size using opencv2's resize function.
+    Arrays are cast into float 32, resized and converted
 
     Args:
         images (list(numpy.ndarray)): List of image arrays to resize
@@ -103,6 +104,7 @@ def resize_image(
 ):
     """
     Resize an image to the specified size using opencv2's resize function.
+    Arrays are cast into float 32, resized and converted
 
     Args:
         image (numpy.ndarray): Image array to resize
@@ -128,6 +130,7 @@ def resize_image(
 
 def _resize_image(image, cfg, output_dtype=None, do_type_conversion=True):
     """Resize an image to the specified size using opencv2's resize function.
+    Arrays are cast into float 32, resized and converted
 
     Args:
         image (np.ndarray): Image array to resize
@@ -166,7 +169,7 @@ def _resize_image(image, cfg, output_dtype=None, do_type_conversion=True):
 
         # cv2 internally returns the input dtype
         image = resize_func(
-            np.ascontiguousarray(image),
+            np.ascontiguousarray(image, dtype=np.float32),
             cfg.size,
             interpolation=interpolation_flag,
         )

--- a/fitsbolt/resize.py
+++ b/fitsbolt/resize.py
@@ -164,8 +164,9 @@ def _resize_image(image, cfg, output_dtype=None, do_type_conversion=True):
         if image.ndim == 3 and image.shape[2] == 1:
             readd_channel = True
 
+        # cv2 internally returns the input dtype
         image = resize_func(
-            image,
+            np.ascontiguousarray(image),
             cfg.size,
             interpolation=interpolation_flag,
         )

--- a/fitsbolt/resize.py
+++ b/fitsbolt/resize.py
@@ -159,11 +159,18 @@ def _resize_image(image, cfg, output_dtype=None, do_type_conversion=True):
 
         downscaling = cfg.size[0] < image.shape[0] or cfg.size[1] < image.shape[1]
         interpolation_flag = cv2.INTER_AREA if downscaling else upscale_interpolation
+        # cv2 drops channel dimension for single-channel images, so we need to add it back
+        readd_channel = False
+        if image.ndim == 3 and image.shape[2] == 1:
+            readd_channel = True
+
         image = resize_func(
             image,
             cfg.size,
             interpolation=interpolation_flag,
         )
+        if readd_channel:
+            image = np.expand_dims(image, axis=-1)
         if do_type_conversion and (cfg.output_dtype is not None or output_dtype is not None):
             if output_dtype:
                 target = output_dtype

--- a/fitsbolt/resize.py
+++ b/fitsbolt/resize.py
@@ -55,6 +55,7 @@ def resize_images(
         size (tuple, optional): Target size for resizing (height, width). If None, no resizing is done.
         interpolation_order (int, optional): Order of interpolation for resizing with opencv2, 0-4. Defaults to 1 = linear
                                              downscaling always uses cv2.INTER_AREA = 4 regardless of this setting.
+                                             0= nearest, 1= linear , 2=cubic, 3= lanczos4, 4= inter_area
         log_level (str, optional): Logging level for the operation. Defaults to "WARNING".
                                    Can be "TRACE", "DEBUG", "INFO", "WARNING", "ERROR", or "CRITICAL".
         use_multiprocessing (bool, optional): Use ProcessPoolExecutor instead of ThreadPoolExecutor.
@@ -113,6 +114,7 @@ def resize_image(
         size (tuple, optional): Target size for resizing (height, width). If None, no resizing is done.
         interpolation_order (int, optional): Order of interpolation for resizing with opencv2, 0-4. Defaults to 1 = linear
                                              downscaling always uses cv2.INTER_AREA = 4 regardless of this setting.
+                                             0= nearest, 1= linear , 2=cubic, 3= lanczos4, 4= inter_area
         log_level (str, optional): Logging level for the operation. Defaults to "WARNING".
                                    Can be "TRACE", "DEBUG", "INFO", "WARNING", "ERROR", or "CRITICAL".
     Returns:

--- a/fitsbolt/resize.py
+++ b/fitsbolt/resize.py
@@ -11,20 +11,17 @@ from tqdm import tqdm
 
 from .cfg.create_config import create_config
 from .cfg.logger import logger
+import cv2
 
-
-# Lazy import for skimage.transform
-_skimage_resize = None
-
-
-def _get_skimage_resize():
-    """Lazy import of skimage.transform.resize."""
-    global _skimage_resize
-    if _skimage_resize is None:
-        from skimage.transform import resize
-
-        _skimage_resize = resize
-    return _skimage_resize
+# Maps the `interpolation` config value to the cv2 upscaling kernel flag.
+# Downscaling always uses cv2.INTER_AREA regardless of this setting.
+_CV2_UPSCALE_INTERPOLATION = {
+    0: cv2.INTER_NEAREST,
+    1: cv2.INTER_LINEAR,
+    2: cv2.INTER_CUBIC,
+    3: cv2.INTER_LANCZOS4,
+    4: cv2.INTER_AREA,  # always used for downscaling
+}
 
 
 def _worker_resize_image(image, cfg):
@@ -48,14 +45,15 @@ def resize_images(
     use_multiprocessing=False,
 ):
     """
-    Resize an image to the specified size using skimage's resize function.
+    Resize an image to the specified size using opencv2's resize function.
 
     Args:
         images (list(numpy.ndarray)): List of image arrays to resize
         output_dtype (type, optional): Desired output data type for the resized images.
                                        Can be np.unit8, np.uint16 or np.float32. Defaults to np.uint8.
         size (tuple, optional): Target size for resizing (height, width). If None, no resizing is done.
-        interpolation_order (int, optional): Order of interpolation for resizing with skimage, 0-5. Defaults to 1.
+        interpolation_order (int, optional): Order of interpolation for resizing with opencv2, 0-4. Defaults to 1 = linear
+                                             downscaling always uses cv2.INTER_AREA = 4 regardless of this setting.
         log_level (str, optional): Logging level for the operation. Defaults to "WARNING".
                                    Can be "TRACE", "DEBUG", "INFO", "WARNING", "ERROR", or "CRITICAL".
         use_multiprocessing (bool, optional): Use ProcessPoolExecutor instead of ThreadPoolExecutor.
@@ -104,14 +102,15 @@ def resize_image(
     image, output_dtype=np.uint8, size=None, interpolation_order=1, log_level="WARNING"
 ):
     """
-    Resize an image to the specified size using skimage's resize function.
+    Resize an image to the specified size using opencv2's resize function.
 
     Args:
         image (numpy.ndarray): Image array to resize
         output_dtype (type, optional): Desired output data type for the resized images.
                                        Can be np.unit8, np.uint16 or np.float32. Defaults to np.uint8.
         size (tuple, optional): Target size for resizing (height, width). If None, no resizing is done.
-        interpolation_order (int, optional): Order of interpolation for resizing with skimage, 0-5. Defaults to 1.
+        interpolation_order (int, optional): Order of interpolation for resizing with opencv2, 0-4. Defaults to 1 = linear
+                                             downscaling always uses cv2.INTER_AREA = 4 regardless of this setting.
         log_level (str, optional): Logging level for the operation. Defaults to "WARNING".
                                    Can be "TRACE", "DEBUG", "INFO", "WARNING", "ERROR", or "CRITICAL".
     Returns:
@@ -128,7 +127,7 @@ def resize_image(
 
 
 def _resize_image(image, cfg, output_dtype=None, do_type_conversion=True):
-    """Resize an image to the specified size using skimage's resize function.
+    """Resize an image to the specified size using opencv2's resize function.
 
     Args:
         image (np.ndarray): Image array to resize
@@ -150,13 +149,20 @@ def _resize_image(image, cfg, output_dtype=None, do_type_conversion=True):
         logger.warning("Received an empty image, returning as is.")
         raise ValueError("Image is empty, cannot resize.")
     if cfg.size is not None and image.shape[:2] != tuple(cfg.size):
-        resize_func = _get_skimage_resize()
+        resize_func = cv2.resize
+
+        upscale_interpolation = (
+            _CV2_UPSCALE_INTERPOLATION[cfg.interpolation_order]
+            if cfg.interpolation_order is not None
+            else cv2.INTER_LINEAR
+        )
+
+        downscaling = cfg.size[0] < image.shape[0] or cfg.size[1] < image.shape[1]
+        interpolation_flag = cv2.INTER_AREA if downscaling else upscale_interpolation
         image = resize_func(
             image,
             cfg.size,
-            anti_aliasing=None,
-            order=cfg.interpolation_order if cfg.interpolation_order is not None else 1,
-            preserve_range=True,
+            interpolation=interpolation_flag,
         )
         if do_type_conversion and (cfg.output_dtype is not None or output_dtype is not None):
             if output_dtype:

--- a/fitsbolt/resize.py
+++ b/fitsbolt/resize.py
@@ -11,17 +11,33 @@ from tqdm import tqdm
 
 from .cfg.create_config import create_config
 from .cfg.logger import logger
-import cv2
 
 # Maps the `interpolation` config value to the cv2 upscaling kernel flag.
 # Downscaling always uses cv2.INTER_AREA regardless of this setting.
-_CV2_UPSCALE_INTERPOLATION = {
-    0: cv2.INTER_NEAREST,
-    1: cv2.INTER_LINEAR,
-    2: cv2.INTER_CUBIC,
-    3: cv2.INTER_LANCZOS4,
-    4: cv2.INTER_AREA,  # always used for downscaling
-}
+# Lazy import for cv2
+_cv2_resize = None
+_CV2_UPSCALE_INTERPOLATION = None
+
+
+def _get_cv2_resize():
+    """Lazy import of cv2.resize."""
+    global _cv2_resize
+    global _CV2_UPSCALE_INTERPOLATION
+    if _cv2_resize is None:
+        from cv2 import resize as cv2_resize
+
+        _cv2_resize = cv2_resize
+    if _CV2_UPSCALE_INTERPOLATION is None:
+        from cv2 import INTER_NEAREST, INTER_LINEAR, INTER_CUBIC, INTER_LANCZOS4, INTER_AREA
+
+        _CV2_UPSCALE_INTERPOLATION = {
+            0: INTER_NEAREST,
+            1: INTER_LINEAR,
+            2: INTER_CUBIC,
+            3: INTER_LANCZOS4,
+            4: INTER_AREA,  # always used for downscaling
+        }
+    return _cv2_resize, _CV2_UPSCALE_INTERPOLATION
 
 
 def _worker_resize_image(image, cfg):
@@ -154,16 +170,16 @@ def _resize_image(image, cfg, output_dtype=None, do_type_conversion=True):
         logger.warning("Received an empty image, returning as is.")
         raise ValueError("Image is empty, cannot resize.")
     if cfg.size is not None and image.shape[:2] != tuple(cfg.size):
-        resize_func = cv2.resize
+        resize_func, _cv2_interpolation_dict = _get_cv2_resize()
 
         upscale_interpolation = (
-            _CV2_UPSCALE_INTERPOLATION[cfg.interpolation_order]
+            _cv2_interpolation_dict[cfg.interpolation_order]
             if cfg.interpolation_order is not None
-            else cv2.INTER_LINEAR
+            else _cv2_interpolation_dict[1]  # Default to linear interpolation if not specified
         )
 
         downscaling = cfg.size[0] < image.shape[0] or cfg.size[1] < image.shape[1]
-        interpolation_flag = cv2.INTER_AREA if downscaling else upscale_interpolation
+        interpolation_flag = _cv2_interpolation_dict[4] if downscaling else upscale_interpolation
         # cv2 drops channel dimension for single-channel images, so we need to add it back
         readd_channel = False
         if image.ndim == 3 and image.shape[2] == 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "numpy>=1.26",
     "scikit-image",
     "tqdm",
-    "opencv-python",
+    "opencv-python-headless>=4.5",
     "pillow",
     "dotmap",
     "tifffile",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "numpy>=1.26",
     "scikit-image",
     "tqdm",
+    "opencv-python",
     "pillow",
     "dotmap",
     "tifffile",

--- a/tests/test_wrapper_functions.py
+++ b/tests/test_wrapper_functions.py
@@ -277,6 +277,16 @@ class TestWrapperFunctionEdgeCases:
         result_3 = resize_images([img], size=[100, 100], interpolation_order=3, show_progress=False)
         assert result_3[0].shape[:2] == (100, 100), "Should resize with order 3"
 
+        # test non square resize, input is a list, output also
+        result_non_square = resize_images(
+            [img], size=[50, 100], interpolation_order=3, show_progress=False
+        )
+        assert result_non_square[0].shape == (
+            50,
+            100,
+            img.shape[-1],
+        ), "Should resize to non-square dimensions"
+
     def test_load_and_process_images_with_no_cfg_provided(self):
         """Test load_and_process_images when no cfg is provided - should create one internally."""
         # This tests the cfg=None branch in load_and_process_images

--- a/tests/test_wrapper_functions.py
+++ b/tests/test_wrapper_functions.py
@@ -274,8 +274,8 @@ class TestWrapperFunctionEdgeCases:
         assert result_0[0].shape[:2] == (100, 100), "Should resize with order 0"
 
         # Test with order 5 (highest order)
-        result_5 = resize_images([img], size=[100, 100], interpolation_order=5, show_progress=False)
-        assert result_5[0].shape[:2] == (100, 100), "Should resize with order 5"
+        result_3 = resize_images([img], size=[100, 100], interpolation_order=3, show_progress=False)
+        assert result_3[0].shape[:2] == (100, 100), "Should resize with order 3"
 
     def test_load_and_process_images_with_no_cfg_provided(self):
         """Test load_and_process_images when no cfg is provided - should create one internally."""


### PR DESCRIPTION
Switches skimage transform resize to opencv2s which is faster.
Always uses inter_area for downscaling
Aligns with functionality in Cutana